### PR TITLE
updated to 0.0.2-SNAPSHOT and other changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,20 +12,11 @@ plugins {
 }
 
 ext {
+    group = "org.cmapi.primitives"
+
+    description = "Common Map Geospatial Notation (CMGN)"
+
     isRelease = project.hasProperty('release') ? true : false
-
-    group   = "org.cmapi.primitives"
-    version = '0.0.1.' + (System.getenv("BUILD_NUMBER") ?: "0")
-
-    if (!isRelease) {
-        version += '-SNAPSHOT'
-    }
-    if (!project.hasProperty("empUsername")) {
-        empUsername = ''
-    }
-    if (!project.hasProperty("empPassword")) {
-        empPassword = ''
-    }
 }
 
 configure (rootProject) {
@@ -76,9 +67,9 @@ configure (rootProject) {
     publishing {
         publications {
             mavenJava(MavenPublication) {
-                groupId    = rootProject.ext.group
+                groupId    = project.ext.group
                 artifactId = project.name
-                version    = rootProject.ext.version
+                version    = project.version
 
                 artifact jar
                 artifact javadocJar
@@ -88,11 +79,11 @@ configure (rootProject) {
         repositories {
             maven {
                 //url "$rootProject.buildDir/_repo"
-                url = isRelease ? nexusReleaseUrl : nexusSnapshotUrl
+                url = project.hasProperty('repositoryUrl') ? project.property('repositoryUrl') : ''
 
                 credentials {
-                    username empUsername
-                    password empPassword
+                    username project.hasProperty('empUsername') ? project.property('empUsername') : ''
+                    password project.hasProperty('empPassword') ? project.property('empPassword') : ''
                 }
             }
         }
@@ -100,7 +91,7 @@ configure (rootProject) {
 }
 
 task wrapper(type: Wrapper, description: "Generates gradlew[.bat] scripts") {
-    gradleVersion = '2.11'
+    gradleVersion = '2.12'
 }
 
 if (JavaVersion.current().isJava8Compatible()) { // disable lint for java8

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,1 @@
-nexusReleaseUrl=https://nexus.di2e.net/nexus/content/repositories/Private_EMP_Releases/
-nexusSnapshotUrl=https://nexus.di2e.net/nexus/content/repositories/Private_EMP_Snapshots/
+version=0.0.2-SNAPSHOT

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Mar 08 10:00:52 EST 2016
+#Fri Apr 08 12:47:53 EDT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.11-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.12-bin.zip


### PR DESCRIPTION
- updated version to 0.0.2-SNAPSHOT
- repositoryUrl should now be supplied when publishing to dictate where the artifacts are to be pushed
- other minor changes
